### PR TITLE
realm-name: Add support for realm urls having '/api' at the end.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,12 @@ function zulip(initialConfig) {
     return parseConfigFile(initialConfig.zuliprc).then(config => resources(config));
   }
   const config = initialConfig;
-  config.apiURL = `${config.realm}/api/v1`;
+  if (config.realm.endsWith('/api')) {
+    config.apiURL = `${config.realm}/v1`;
+  } else {
+    config.apiURL = `${config.realm}/api/v1`;
+  }
+
   if (!config.apiKey) {
     return accounts(config).retrieve().then((res) => {
       config.apiKey = res.api_key;

--- a/test/index.js
+++ b/test/index.js
@@ -31,4 +31,12 @@ describe('Initialization', () => {
         .should.eventually.have.property('status', 200);
     });
   });
+
+  describe('With API Key ending with /api', () => {
+    it('Should get 200 on API request', () => {
+      config.apiKey = `${process.env.ZULIP_API_KEY}/api`;
+      lib(config).streams.subscriptions.retrieve()
+        .should.eventually.have.property('status', 200);
+    });
+  });
 });


### PR DESCRIPTION
Relevant conversation on:
1. https://chat.zulip.org/#narrow/stream/bots/topic/zulip-js.20api.20bindings
2. https://chat.zulip.org/#narrow/stream/test.20here/topic/github-issues