### PR TITLE
api: Add POST /users/me/subscriptions endpoint. Fixes #14.

### DIFF
--- a/examples/subscriptions.js
+++ b/examples/subscriptions.js
@@ -1,0 +1,20 @@
+const config = {
+  username: process.env.ZULIP_USERNAME,
+  apiKey: process.env.ZULIP_APIKEY,
+  realm: process.env.ZULIP_REALM,
+};
+
+const zulip = require('../lib/')(config);
+
+// Prints
+//   { msg: '',
+//     subscribed: { 'aero31aero@gmail.com': [ 'off topic' ] },
+//     already_subscribed: {},
+//     result: 'success' }
+
+const params = {
+  subscriptions: JSON.stringify([{ name: 'off topic' }]),
+};
+zulip.users.me.subscriptions.add(params).then((data) => {
+  console.log(data);
+});

--- a/src/resources/users.js
+++ b/src/resources/users.js
@@ -13,6 +13,12 @@ function users(config) {
           return api(url, config, 'GET', params);
         },
       },
+      subscriptions: {
+        add: (params) => {
+          const url = `${config.apiURL}/users/me/subscriptions`;
+          return api(url, config, 'POST', params);
+        },
+      },
     },
   };
 }

--- a/test/resources/users.js
+++ b/test/resources/users.js
@@ -52,4 +52,23 @@ describe('Users', () => {
     users(common.config).me.pointer.retrieve().should.eventually.have.property('result', 'success');
     common.restoreStubs(stubs);
   });
+  it('should subscribe user to stream', () => {
+    const params = {
+      subscriptions: JSON.stringify([{ name: 'off topic' }]),
+    };
+    const validator = (url, options) => {
+      url.should.equal(`${common.config.apiURL}/users/me/subscriptions`);
+      options.should.have.property('body');
+      Object.keys(options.body.data).length.should.equal(1);
+      options.body.data.subscriptions.should.equal(params.subscriptions);
+    };
+    const output = {
+      already_subscribed: {},
+      result: 'success',
+    };
+    output[common.config.username] = ['off topic'];
+    const stubs = common.getStubs(validator, output);
+    users(common.config).me.subscriptions.add(params).should.eventually.have.property('result', 'success');
+    common.restoreStubs(stubs);
+  });
 });


### PR DESCRIPTION
The endpoint to view existing subscriptions was in `zulip.streams.subscriptions.retrieve()` and since it didn't match the actual endpoint `/users/me/subscriptions`, I added this to the `zulip.users.me.subscriptions.add()` endpoint instead.

Added an example file to show usage. Since the testing framework is not exactly functional right now, didn't write any tests. I was working on mocking some stuff on a separate branch, would push that soon in another PR.

Sorry for the delay here. Hope it isn't too late. Fixes #14