### PR TITLE
Proof of concept standalone tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,20 +16,21 @@
   "devDependencies": {
     "babel-cli": "^6.14.0",
     "babel-preset-es2015": "^6.14.0",
+    "chai": "^3.5.0",
+    "chai-as-promised": "^5.3.0",
     "eslint": "^3.5.0",
     "eslint-config-airbnb": "^11.1.0",
     "eslint-plugin-import": "^1.15.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.2.0",
     "mocha": "^3.0.2",
-    "chai-as-promised": "^5.3.0",
-    "chai": "^3.5.0"
+    "sinon": "^4.1.2"
   },
   "scripts": {
     "compile": "babel --presets es2015 -d lib/ src/",
     "prepublish": "npm run compile",
     "lint": "eslint src test examples",
-    "test": "npm run lint && mocha --recursive"
+    "test": "npm run lint && mocha test/resources/accounts.js"
   },
   "repository": {
     "type": "git",

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,5 @@
 require('es6-promise').polyfill();
-require('isomorphic-fetch');
-require('isomorphic-form-data');
+const helper = require('./helper');
 
 function api(baseUrl, config, method, params) {
   let url = baseUrl;
@@ -8,7 +7,7 @@ function api(baseUrl, config, method, params) {
   const authHeader = `Basic ${auth}`;
   const options = { method, headers: { Authorization: authHeader } };
   if (method === 'POST') {
-    options.body = new FormData();
+    options.body = new helper.FormData();
     Object.keys(params).forEach((key) => {
       options.body.append(key, params[key]);
     });
@@ -17,7 +16,7 @@ function api(baseUrl, config, method, params) {
     const queryParams = Object.keys(params).map(generateQueryParam);
     url = `${url}?${queryParams.join('&')}`;
   }
-  return fetch(url, options).then(res => res.json());
+  return helper.fetch(url, options).then(res => res.json());
 }
 
 module.exports = api;

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,7 @@
+const fetch = require('isomorphic-fetch');
+const FormData = require('isomorphic-form-data');
+
+module.exports = {
+  fetch,
+  FormData,
+};

--- a/src/resources/accounts.js
+++ b/src/resources/accounts.js
@@ -1,15 +1,15 @@
 require('es6-promise').polyfill();
-require('isomorphic-fetch');
-require('isomorphic-form-data');
+
+const helper = require('../helper');
 
 function accounts(config) {
   return {
     retrieve: () => {
       const url = `${config.apiURL}/fetch_api_key`;
-      const form = new FormData();
+      const form = new helper.FormData();
       form.append('username', config.username);
       form.append('password', config.password);
-      return fetch(url, {
+      return helper.fetch(url, {
         method: 'POST',
         body: form,
       }).then(res => res.json());

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,43 @@
+const sinon = require('sinon');
+const helper = require('../lib/helper');
+
+const getFakes = (validator, output) => {
+  const fetch = (url, options) => {
+    validator(url, options);
+    const rval = (function () {
+      const json = function () {
+        return output;
+      };
+      return {
+        json,
+      };
+    }());
+    return Promise.resolve(rval);
+  };
+  const FormData = () => {
+    const data = {};
+    return {
+      append(key, value) {
+        data[key] = value;
+      },
+      data,
+    };
+  };
+  return {
+    fetch,
+    FormData,
+  };
+};
+
+const getStubs = (validator, output) => {
+  const stubs = [];
+  const fakes = getFakes(validator, output);
+  stubs.push(sinon.stub(helper, 'fetch').callsFake(fakes.fetch));
+  stubs.push(sinon.stub(helper, 'FormData').callsFake(fakes.FormData));
+  return stubs;
+};
+
+module.exports = {
+  getFakes,
+  getStubs,
+};


### PR DESCRIPTION
tests: Replace accounts.js tests with standalone tests.

Stubs the fetch and formdata modules to get standalone testing done.

Also, wraps the above modules in a helper module so that it becomes
an object and can be stubbed with sinon. Without this, it is not
possible to stub them.

@timabbott @showell  please take a look once and tell me if this approach looks good. I was planning on trying to get this repository ready for GCI.