### PR TITLE
api: Expose the call_endpoint method for generic API calls.

### DIFF
--- a/examples/call_endpoint.js
+++ b/examples/call_endpoint.js
@@ -1,0 +1,18 @@
+const zulip = require('../lib/');
+
+const config = {
+  username: process.env.ZULIP_USERNAME,
+  password: process.env.ZULIP_PASSWORD,
+  realm: process.env.ZULIP_REALM,
+};
+
+const sendParams = {
+  to: 'bot testing',
+  type: 'stream',
+  subject: 'Testing zulip-js',
+  content: 'Something is horribly wrong....',
+};
+
+const z = zulip(config);
+
+z.callEndpoint('/messages', 'POST', sendParams);

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "compile": "babel --presets es2015 -d lib/ src/",
     "prepublish": "npm run compile",
     "lint": "eslint src test examples",
-    "test": "npm run lint && mocha test/resources/**/*.js"
+    "test": "npm run lint && npm run compile && mocha test/*"
   },
   "repository": {
     "type": "git",

--- a/test/common.js
+++ b/test/common.js
@@ -47,6 +47,7 @@ const config = {
   username: 'valid@email.com',
   apiKey: 'randomcharactersonlyq32YIpC8aMSH',
   apiURL: 'valid.realm.url/api/v1',
+  realm: 'valid.realm.url/api',
 };
 
 module.exports = {

--- a/test/index.js
+++ b/test/index.js
@@ -1,42 +1,46 @@
-const lib = require('..');
+const lib = require('../lib/index');
+const common = require('./common');
 const chai = require('chai');
-const path = require('path');
 chai.use(require('chai-as-promised'));
 
-const config = {
-  username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
-  realm: process.env.ZULIP_REALM,
+chai.should();
+
+const params = {
+  one: '123',
+  two: '456',
 };
 
-chai.should();
-describe('Initialization', () => {
-  describe('With zuliprc', () => {
-    it('Should read API key from zuliprc', () => {
-      const zuliprc = path.resolve(__dirname, 'zuliprc');
-      lib({ zuliprc }).should.eventually.have.deep.property('config.apiKey');
-    });
-  });
+const output = {
+  data: 'random',
+  msg: '',
+  result: 'success',
+};
 
-  describe('With username & password', () => {
-    it('Should get API key', () => {
-      lib(config).should.eventually.have.deep.property('config.apiKey');
-    });
+describe('Index', () => {
+  it('should call get endpoints', () => {
+    const validator = (url, options) => {
+      url.should.contain(`${common.config.apiURL}/testurl`);
+      options.should.not.have.property('body');
+      const urldata = url.split('?', 2)[1].split('&'); // URL: host/messages?key=value&key=value...
+      urldata.length.should.equal(2);
+      urldata.should.contain(`one=${params.one}`);
+      urldata.should.contain(`two=${params.two}`);
+    };
+    const stubs = common.getStubs(validator, output);
+    lib(common.config).callEndpoint('/testurl', 'GET', params).should.eventually.have.property('result', 'success');
+    lib(common.config).callEndpoint('testurl', 'GET', params).should.eventually.have.property('result', 'success');
+    common.restoreStubs(stubs);
   });
-
-  describe('With API Key', () => {
-    it('Should get 200 on API request', () => {
-      config.apiKey = process.env.ZULIP_API_KEY;
-      lib(config).streams.subscriptions.retrieve()
-        .should.eventually.have.property('status', 200);
-    });
-  });
-
-  describe('With API Key ending with /api', () => {
-    it('Should get 200 on API request', () => {
-      config.apiKey = `${process.env.ZULIP_API_KEY}/api`;
-      lib(config).streams.subscriptions.retrieve()
-        .should.eventually.have.property('status', 200);
-    });
+  it('should call post endpoints', () => {
+    const validator = (url, options) => {
+      url.should.contain(`${common.config.apiURL}/testurl`);
+      Object.keys(options.body.data).length.should.equal(2);
+      options.body.data.one.should.equal(params.one);
+      options.body.data.two.should.equal(params.two);
+    };
+    const stubs = common.getStubs(validator, output);
+    lib(common.config).callEndpoint('/testurl', 'POST', params).should.eventually.have.property('result', 'success');
+    lib(common.config).callEndpoint('testurl', 'POST', params).should.eventually.have.property('result', 'success');
+    common.restoreStubs(stubs);
   });
 });

--- a/test/zuliprc
+++ b/test/zuliprc
@@ -1,4 +1,0 @@
-[api]
-email=cordelia@zulip.com
-key=wlueAg7cQXqKpUgIaPP3dmF4vibZXal7
-site=http://localhost:9991


### PR DESCRIPTION
Fixes #21.

Had to disable eslint in two cases for 1. trying to enforce camel case and 2. trying to not let modify function parameters.