### PR TITLE
api: Add messsages/render endpoint.

### DIFF
--- a/src/resources/messages.js
+++ b/src/resources/messages.js
@@ -14,6 +14,16 @@ function messages(config) {
       const url = `${config.apiURL}/messages`;
       return api(url, config, 'POST', params);
     },
+    render: (initialParams) => {
+      const url = `${config.apiURL}/messages/render`;
+      let params = initialParams;
+      if (typeof (initialParams) === 'string') {
+        params = {
+          content: initialParams,
+        };
+      }
+      return api(url, config, 'POST', params);
+    },
   };
 }
 

--- a/test/resources/messages.js
+++ b/test/resources/messages.js
@@ -59,4 +59,24 @@ describe('Messages', () => {
     messages(common.config).retrieve(params).should.eventually.have.property('result', 'success');
     common.restoreStubs(stubs);
   });
+
+  it('should render messages', () => {
+    const params = {
+      content: 'Hello **world**',
+    };
+    const validator = (url, options) => {
+      url.should.equal(`${common.config.apiURL}/messages/render`);
+      Object.keys(options.body.data).length.should.equal(1);
+      options.body.data.content.should.equal(params.content);
+    };
+    const output = {
+      result: 'success',
+      msg: '',
+      rendered: '<p>Hello <strong>world</strong></p>',
+    };
+    const stubs = common.getStubs(validator, output);
+    messages(common.config).render(params).should.eventually.have.property('result', 'success');
+    messages(common.config).render(params.content).should.eventually.have.property('result', 'success');
+    common.restoreStubs(stubs);
+  });
 });


### PR DESCRIPTION
Fixes #22. Adds support for passing the data directly as a String as well
as using a JSON object like {content: "Message Here"}.