### PR TITLE
queues.js: Add deregister method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ zulip.callEndpoint('/messages', 'POST', params);
 | `zulip.messages.retrieve()` | GET `/messages` | returns a promise that can be used to retrieve messages from a stream. You need to specify the id of the message to be used as an anchor. Use `1000000000` to retrieve the most recent message, or [`zulip.users.me.pointer.retrieve()`](#fetching-a-pointer-for-a-user) to get the id of the last message the user read. |
 | `zulip.messages.render()` | POST `/messages/render` | returns a promise that can be used to get rendered HTML for a message text. |
 | `zulip.queues.register()` | POST `/register` | registers a new queue. You can pass it a params object with the types of events you are interested in and whether you want to receive raw text or html (using markdown). |
+| `zulip.queues.deregister()` | DELETE `/events` | deletes a previously registered queue. |
 | `zulip.streams.retrieve()` | GET `/streams` | returns a promise that can be used to retrieve all streams. |
 | `zulip.streams.getStreamId()` | GET `/get_stream_id` | returns a promise that can be used to retrieve a stream's id. |
 | `zulip.streams.subscriptions.retrieve()` | GET `/users/me/subscriptions` | returns a promise that can be used to retrieve the user's subscriptions. |

--- a/examples/queues.js
+++ b/examples/queues.js
@@ -21,3 +21,18 @@ zulip(config).then((z) => {
 
   return z.queues.register(params).then(console.log);
 }).catch(err => console.log(err.msg));
+
+zulip(config).then((z) => {
+  // Delete a previously registered queue
+  const params = {
+    queue_id: '1511901550:2',
+  };
+
+  // Prints
+  // {
+  //   msg: '',
+  //   result: 'success',
+  // }
+
+  return z.queues.deregister(params).then(console.log);
+}).catch(err => console.log(err.msg));

--- a/src/resources/queues.js
+++ b/src/resources/queues.js
@@ -10,6 +10,10 @@ function queues(config) {
       }
       return api(url, config, 'POST', params);
     },
+    deregister: (params) => {
+      const url = `${config.apiURL}/events`;
+      return api(url, config, 'DELETE', params);
+    },
   };
 }
 

--- a/test/resources/queues.js
+++ b/test/resources/queues.js
@@ -27,4 +27,21 @@ describe('Queues', () => {
     queues(common.config).register(params).should.eventually.have.property('result', 'success');
     common.restoreStubs(stubs);
   });
+
+  it('should deregister queue', () => {
+    const params = {
+      queue_id: '1511901550:2',
+    };
+    const output = {
+      msg: '',
+      result: 'success',
+    };
+    const validator = (url, options) => {
+      url.should.contain(`${common.config.apiURL}/events`);
+      options.should.not.have.property('body');
+    };
+    const stubs = common.getStubs(validator, output);
+    queues(common.config).deregister(params).should.eventually.have.property('result', 'success');
+    common.restoreStubs(stubs);
+  });
 });


### PR DESCRIPTION
This commit adds a method called queues.deregister that allows
one to call the `DELETE /api/v1/events` endpoint and delete a
previously registered queue.

Fixes #29.

@aero31aero FYI :) This is the first time I've ever written anything in JavaScript lol