### PR TITLE
 tests: Improve failure reporting by using then-catch.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ const output = {
 };
 
 describe('Index', () => {
-  it('should call get endpoints', () => {
+  it('should call get endpoints', (done) => {
     const validator = (url, options) => {
       url.should.contain(`${common.config.apiURL}/testurl`);
       options.should.not.have.property('body');
@@ -31,15 +31,16 @@ describe('Index', () => {
       z.callEndpoint('/testurl', 'GET', params)
       .should.eventually.have.property('result', 'success');
       common.restoreStubs(stubs);
-    });
-    lib(common.config).then((z) => {
+      return lib(common.config);
+    }).then((z) => {
       const stubs = common.getStubs(validator, output);
       z.callEndpoint('testurl', 'GET', params)
       .should.eventually.have.property('result', 'success');
       common.restoreStubs(stubs);
-    });
+      done();
+    }).catch(done);
   });
-  it('should call post endpoints', () => {
+  it('should call post endpoints', (done) => {
     const validator = (url, options) => {
       url.should.contain(`${common.config.apiURL}/testurl`);
       Object.keys(options.body.data).length.should.equal(2);
@@ -51,12 +52,13 @@ describe('Index', () => {
       z.callEndpoint('/testurl', 'POST', params)
       .should.eventually.have.property('result', 'success');
       common.restoreStubs(stubs);
-    });
-    lib(common.config).then((z) => {
+      return lib(common.config);
+    }).then((z) => {
       const stubs = common.getStubs(validator, output);
       z.callEndpoint('testurl', 'POST', params)
       .should.eventually.have.property('result', 'success');
       common.restoreStubs(stubs);
-    });
+      done();
+    }).catch(done);
   });
 });

--- a/test/resources/accounts.js
+++ b/test/resources/accounts.js
@@ -20,7 +20,7 @@ const validator = (url, options) => {
 };
 
 describe('Accounts', () => {
-  it('should get API key', () => {
+  it('should get API key', (done) => {
     const output = {
       result: 'success',
       msg: '',
@@ -28,18 +28,26 @@ describe('Accounts', () => {
       email: config.email,
     };
     const stubs = common.getStubs(validator, output);
-    accounts(config).retrieve().should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    accounts(config).retrieve()
+    .then((data) => {
+      data.result.should.be.equal('success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('should return error on incorrect password', () => {
+  it('should return error on incorrect password', (done) => {
     const output = {
       result: 'error',
       msg: 'Your username or password is incorrect.',
       reason: 'incorrect_creds',
     };
     const stubs = common.getStubs(validator, output);
-    accounts(config).retrieve().should.eventually.have.property('result', 'error');
-    common.restoreStubs(stubs);
+    accounts(config).retrieve()
+    .then((data) => {
+      data.result.should.be.equal('error');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 });

--- a/test/resources/emojis.js
+++ b/test/resources/emojis.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Emojis', () => {
-  it('should fetch emojis', () => {
+  it('should fetch emojis', (done) => {
     const validator = (url, options) => {
       url.should.equal(`${common.config.apiURL}/realm/emoji`);
       options.should.not.have.property('body');
@@ -23,7 +23,11 @@ describe('Emojis', () => {
       result: 'success',
     };
     const stubs = common.getStubs(validator, output);
-    emojis(common.config).retrieve().should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    emojis(common.config).retrieve()
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 });

--- a/test/resources/events.js
+++ b/test/resources/events.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Events', () => {
-  it('should fetch events', () => {
+  it('should fetch events', (done) => {
     const params = {
       last_event_id: -1,
       dont_block: true,
@@ -31,7 +31,11 @@ describe('Events', () => {
       queue_id: '1511901550:3',
     };
     const stubs = common.getStubs(validator, output);
-    events(common.config).retrieve(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    events(common.config).retrieve(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 });

--- a/test/resources/messages.js
+++ b/test/resources/messages.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Messages', () => {
-  it('should send message to test stream', () => {
+  it('should send message to test stream', (done) => {
     const params = {
       to: 'test stream',
       type: 'stream',
@@ -27,11 +27,15 @@ describe('Messages', () => {
       id: 168,
     };
     const stubs = common.getStubs(validator, output);
-    messages(common.config).send(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    messages(common.config).send(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('should fetch messages from test stream', () => {
+  it('should fetch messages from test stream', (done) => {
     const params = {
       stream: 'test stream',
       type: 'stream',
@@ -56,11 +60,15 @@ describe('Messages', () => {
       messages: [], // TODO expand test with actual API message data.
     };
     const stubs = common.getStubs(validator, output);
-    messages(common.config).retrieve(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    messages(common.config).retrieve(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('should render messages', () => {
+  it('should render messages', (done) => {
     const params = {
       content: 'Hello **world**',
     };
@@ -75,11 +83,19 @@ describe('Messages', () => {
       rendered: '<p>Hello <strong>world</strong></p>',
     };
     const stubs = common.getStubs(validator, output);
-    messages(common.config).render(params).should.eventually.have.property('result', 'success');
-    messages(common.config).render(params.content).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    messages(common.config).render(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      return messages(common.config).render(params.content);
+    }).then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    })
+    .catch(done);
   });
-  it('should update message', () => {
+
+  it('should update message', (done) => {
     const params = {
       message_id: 131,
       content: 'New content',
@@ -94,7 +110,11 @@ describe('Messages', () => {
       result: 'success',
     };
     const stubs = common.getStubs(validator, output);
-    messages(common.config).update(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    messages(common.config).update(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 });

--- a/test/resources/queues.js
+++ b/test/resources/queues.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Queues', () => {
-  it('should register queue', () => {
+  it('should register queue', (done) => {
     const params = {
       event_types: ['message'],
     };
@@ -24,11 +24,15 @@ describe('Queues', () => {
       options.body.data.event_types.should.be.equal('["message"]');
     };
     const stubs = common.getStubs(validator, output);
-    queues(common.config).register(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    queues(common.config).register(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('should deregister queue', () => {
+  it('should deregister queue', (done) => {
     const params = {
       queue_id: '1511901550:2',
     };
@@ -41,7 +45,11 @@ describe('Queues', () => {
       options.should.not.have.property('body');
     };
     const stubs = common.getStubs(validator, output);
-    queues(common.config).deregister(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    queues(common.config).deregister(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 });

--- a/test/resources/streams.js
+++ b/test/resources/streams.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Streams', () => {
-  it('should fetch streams', () => {
+  it('should fetch streams', (done) => {
     const validator = (url, options) => {
       url.should.contain(`${common.config.apiURL}/streams`);
       options.should.not.have.property('body');
@@ -42,10 +42,15 @@ describe('Streams', () => {
       }],
     };
     const stubs = common.getStubs(validator, output);
-    streams(common.config).retrieve().should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    streams(common.config).retrieve()
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
-  it('should fetch subscriptions', () => {
+
+  it('should fetch subscriptions', (done) => {
     const params = {
       subscriptions: JSON.stringify([{ name: 'off topic' }]),
     };
@@ -88,11 +93,15 @@ describe('Streams', () => {
       }],
     };
     const stubs = common.getStubs(validator, output);
-    streams(common.config).subscriptions.retrieve(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    streams(common.config).subscriptions.retrieve(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('should fetch stream id', () => {
+  it('should fetch stream id', (done) => {
     const params = {
       stream: 'bot testing',
     };
@@ -109,8 +118,15 @@ describe('Streams', () => {
       stream_id: 94,
     };
     const stubs = common.getStubs(validator, output);
-    streams(common.config).getStreamId(params).should.eventually.have.property('result', 'success');
-    streams(common.config).getStreamId(params.stream).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    streams(common.config).getStreamId(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      return streams(common.config).getStreamId(params.stream);
+    }).then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    })
+    .catch(done);
   });
 });

--- a/test/resources/typing.js
+++ b/test/resources/typing.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Typing', () => {
-  it('Should send typing started notification', () => {
+  it('Should send typing started notification', (done) => {
     const params = {
       to: 'othello@zulip.com',
       op: 'start',
@@ -30,11 +30,15 @@ describe('Typing', () => {
       handler_id: 225,
     };
     const stubs = common.getStubs(validator, output);
-    typing(common.config).send(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    typing(common.config).send(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('Should send typing stopped notification', () => {
+  it('Should send typing stopped notification', (done) => {
     const params = {
       to: 'othello@zulip.com',
       op: 'stop',
@@ -58,7 +62,11 @@ describe('Typing', () => {
       handler_id: 286,
     };
     const stubs = common.getStubs(validator, output);
-    typing(common.config).send(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    typing(common.config).send(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 });

--- a/test/resources/users.js
+++ b/test/resources/users.js
@@ -6,7 +6,7 @@ chai.use(require('chai-as-promised'));
 chai.should();
 
 describe('Users', () => {
-  it('should fetch users', () => {
+  it('should fetch users', (done) => {
     const validator = (url, options) => {
       url.should.equal(`${common.config.apiURL}/users`);
       options.should.not.have.property('body');
@@ -35,10 +35,15 @@ describe('Users', () => {
       }],
     };
     const stubs = common.getStubs(validator, output);
-    users(common.config).retrieve().should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    users(common.config).retrieve()
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
-  it('should fetch pointer for user', () => {
+
+  it('should fetch pointer for user', (done) => {
     const validator = (url, options) => {
       url.should.equal(`${common.config.apiURL}/users/me/pointer`);
       options.should.not.have.property('body');
@@ -49,10 +54,15 @@ describe('Users', () => {
       result: 'success',
     };
     const stubs = common.getStubs(validator, output);
-    users(common.config).me.pointer.retrieve().should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    users(common.config).me.pointer.retrieve()
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
-  it('should fetch user profile', () => {
+
+  it('should fetch user profile', (done) => {
     const validator = (url, options) => {
       url.should.equal(`${common.config.apiURL}/users/me/getProfile`);
       options.should.not.have.property('body');
@@ -71,10 +81,15 @@ describe('Users', () => {
       is_admin: false,
     };
     const stubs = common.getStubs(validator, output);
-    users(common.config).me.getProfile().should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    users(common.config).me.getProfile()
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
-  it('should subscribe user to stream', () => {
+
+  it('should subscribe user to stream', (done) => {
     const params = {
       subscriptions: JSON.stringify([{ name: 'off topic' }]),
     };
@@ -90,11 +105,15 @@ describe('Users', () => {
     };
     output[common.config.username] = ['off topic'];
     const stubs = common.getStubs(validator, output);
-    users(common.config).me.subscriptions.add(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    users(common.config).me.subscriptions.add(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('should remove subscriptions', () => {
+  it('should remove subscriptions', (done) => {
     const params = {
       subscriptions: JSON.stringify(['Verona']),
     };
@@ -110,11 +129,15 @@ describe('Users', () => {
       removed: JSON.stringify(['Verona']),
     };
     const stubs = common.getStubs(validator, output);
-    users(common.config).me.subscriptions.remove(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    users(common.config).me.subscriptions.remove(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 
-  it('should create a new user', () => {
+  it('should create a new user', (done) => {
     const params = {
       email: 'newbie@zulip.com',
       password: 'temp',
@@ -136,7 +159,11 @@ describe('Users', () => {
       msg: '',
     };
     const stubs = common.getStubs(validator, output);
-    users(common.config).create(params).should.eventually.have.property('result', 'success');
-    common.restoreStubs(stubs);
+    users(common.config).create(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
   });
 });


### PR DESCRIPTION
Previously, there was a huge error in the test framework that even
chai threw an error and reected the promise, we didn't catch it and
fail the test. Instead, it just logged an unhandled Promise rejection
warning in the console. Thus, any failing tests of promises could be
detected only by looking at the tests when running them. This PR
fixes this for two of the files.

Also, as a minor fix, we now check for the HTTP method as well in the
requests being made in these two files.

Files updates: test/index.js and test/resources/accounts.js.