### PR TITLE
examples: Use apiKey instead of password in config.

### DIFF
--- a/examples/accounts.js
+++ b/examples/accounts.js
@@ -2,7 +2,7 @@ const zulip = require('../lib/');
 
 zulip({
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 }).then(z => z.accounts.retrieve())
   .then(console.log);

--- a/examples/call_endpoint.js
+++ b/examples/call_endpoint.js
@@ -2,7 +2,7 @@ const zulip = require('../lib/');
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/emojis.js
+++ b/examples/emojis.js
@@ -2,7 +2,7 @@ const zulip = require('../lib/');
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/events.js
+++ b/examples/events.js
@@ -2,7 +2,7 @@ const zulip = require('../lib/');
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/init.js
+++ b/examples/init.js
@@ -3,7 +3,7 @@ const path = require('path');
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 
@@ -16,7 +16,7 @@ zulip({ zuliprc }).then((z) => {
 }).then(console.log)
   .catch(err => console.log(err.message));
 
-// Initialization with username & password
+// Initialization with username & API key
 zulip(config).then((z) => {
   // The zulip object now contains the API key
   console.log(z.config);

--- a/examples/messages.js
+++ b/examples/messages.js
@@ -11,7 +11,7 @@ const sendParams = {
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/private-messages.js
+++ b/examples/private-messages.js
@@ -9,7 +9,7 @@ const sendParams = {
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/queues.js
+++ b/examples/queues.js
@@ -2,7 +2,7 @@ const zulip = require('../lib/');
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/streams.js
+++ b/examples/streams.js
@@ -2,7 +2,7 @@ const zulip = require('../lib/');
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/typing-notifications/send.js
+++ b/examples/typing-notifications/send.js
@@ -7,7 +7,7 @@ if (process.env.ZULIP_TYPING_RECIPIENT) {
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apiKey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 

--- a/examples/users.js
+++ b/examples/users.js
@@ -2,7 +2,7 @@ const zulip = require('../lib/');
 
 const config = {
   username: process.env.ZULIP_USERNAME,
-  password: process.env.ZULIP_PASSWORD,
+  apikey: process.env.ZULIP_API_KEY,
   realm: process.env.ZULIP_REALM,
 };
 


### PR DESCRIPTION
This updates all the examples we use, to look similar to /api docs.

Fixes #41.