### PR TITLE
users: Use correct URL for API request.

### DIFF
--- a/src/resources/users.js
+++ b/src/resources/users.js
@@ -18,7 +18,7 @@ function users(config) {
         },
       },
       getProfile: () => {
-        const url = `${config.apiURL}/users/me/getProfile`;
+        const url = `${config.apiURL}/users/me`;
         return api(url, config, 'GET');
       },
       subscriptions: {

--- a/test/resources/users.js
+++ b/test/resources/users.js
@@ -56,7 +56,7 @@ describe('Users', () => {
   });
   it('should fetch user profile', () => {
     const validator = (url, options) => {
-      url.should.equal(`${common.config.apiURL}/users/me/getProfile`);
+      url.should.equal(`${common.config.apiURL}/users/me`);
       options.method.should.be.equal('GET');
       options.should.not.have.property('body');
     };


### PR DESCRIPTION
/users/me/getProfile is not a valid URL.

@aero31aero: FYI

@Balaji2198: The URL you used when writing this method was invalid. I would recommend always testing your code locally with a running Zulip server instance and making an API request before submitting a PR. The problem with this repo is that it isn't automatically tested against a running Zulip instance (I plan on fixing this soon-ish), so we have to be very careful when writing new methods! :)