### PR TITLE
Add browser field to package.json to ignore fs-readfile-promise

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "directories": {
     "test": "test"
   },
+  "browser": {
+    "fs-read-file-promise": false
+  },
   "dependencies": {
     "es6-promise": "^3.2.1",
     "fs-readfile-promise": "^3.0.0",


### PR DESCRIPTION
Some bundlers including Browserify[1] and Parcel[2] use the browser field in package.json to ignore modules (using browser-resolve[3]) that do not work well with browsers.
In our case this is the zuliprc related module, fs-readfile-promise.

This commit adds a browser field with fs-readfile-promise set to false to the package.json, so that clients that are bundled with Browserify or Parcel can use zulip-js out of the box.

1: https://github.com/browserify/browserify-handbook#browser-field
2: https://github.com/parcel-bundler/parcel/issues/200
3: https://github.com/defunctzombie/node-browser-resolve