### PR TITLE
WIP add support for bulk adding/removing a flag to messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ zulip.callEndpoint('/messages', 'POST', params);
 | `zulip.messages.retrieve()` | GET `/messages` | returns a promise that can be used to retrieve messages from a stream. You need to specify the id of the message to be used as an anchor. Use `1000000000` to retrieve the most recent message, or [`zulip.users.me.pointer.retrieve()`](#fetching-a-pointer-for-a-user) to get the id of the last message the user read. |
 | `zulip.messages.render()` | POST `/messages/render` | returns a promise that can be used to get rendered HTML for a message text. |
 | `zulip.messages.update()` | PATCH `/messages/<msg_id>` | updates the content or topic of the message with the given `msg_id`. |
+| `zulip.messages.flags.add()` | POST `/messages/flags` | add a flag to a list of messages. Its params are `flag` which is one of `[read, starred, mentioned, wildcard_mentioned, has_alert_word, historical]` and `messages` which is a list of messageIDs. |
+| `zulip.messages.flags.remove()` | POST `/messages/flags` | remove a flag from a list of messages. Its params are `flag` which is one of `[read, starred, mentioned, wildcard_mentioned, has_alert_word, historical]` and `messages` which is a list of messageIDs. |
 | `zulip.queues.register()` | POST `/register` | registers a new queue. You can pass it a params object with the types of events you are interested in and whether you want to receive raw text or html (using markdown). |
 | `zulip.queues.deregister()` | DELETE `/events` | deletes a previously registered queue. |
 | `zulip.streams.retrieve()` | GET `/streams` | returns a promise that can be used to retrieve all streams. |

--- a/examples/messages.js
+++ b/examples/messages.js
@@ -47,5 +47,15 @@ zulip(config).then((z) => {
       readParams.anchor = resp.pointer;
       z.messages.retrieve(readParams).then(console.log);
     });
+    // Add a flag for the message that was sent
+    const flagParams = {
+      messages: [res.id],
+      flag: 'read',
+    };
+    z.messages.flags.add(flagParams).then((resp) => {
+      console.log(resp);
+      // Remove the flag for the message that was sent
+      z.messages.flags.remove(flagParams).then(console.log);
+    });
   }).then(res => console.log(res.messages));
 }).catch(err => console.log(err.message));

--- a/src/resources/messages.js
+++ b/src/resources/messages.js
@@ -1,6 +1,8 @@
 const api = require('../api');
 
 function messages(config) {
+  const baseURL = `${config.apiURL}/messages`;
+  const flagsURL = `${baseURL}/flags`;
   return {
     retrieve: (initialParams) => {
       const url = `${config.apiURL}/messages`;
@@ -27,6 +29,28 @@ function messages(config) {
     update: (params) => {
       const url = `${config.apiURL}/messages/${params.message_id}`;
       return api(url, config, 'PATCH', params);
+    },
+    flags: {
+      add: (initialParams) => {
+        // params.flag can be one of 'read', 'starred', 'mentioned',
+        // 'wildcard_mentioned', 'has_alert_word', 'historical',
+        const params = initialParams;
+        params.op = 'add';
+        if (params.messages) {
+          params.messages = JSON.stringify(params.messages);
+        }
+        return api(flagsURL, config, 'POST', params);
+      },
+      remove: (initialParams) => {
+        // params.flag can be one of 'read', 'starred', 'mentioned',
+        // 'wildcard_mentioned', 'has_alert_word', 'historical',
+        const params = initialParams;
+        params.op = 'remove';
+        if (params.messages) {
+          params.messages = JSON.stringify(params.messages);
+        }
+        return api(flagsURL, config, 'POST', params);
+      },
     },
   };
 }

--- a/test/resources/messages.js
+++ b/test/resources/messages.js
@@ -120,4 +120,56 @@ describe('Messages', () => {
       done();
     }).catch(done);
   });
+
+  it('should mark message as read', (done) => {
+    const params = {
+      flag: 'read',
+      messages: [131],
+    };
+    const validator = (url, options) => {
+      url.should.contain(`${common.config.apiURL}/messages/flags`);
+      options.method.should.be.equal('POST');
+      Object.keys(options.body.data).length.should.equal(3);
+      options.body.data.flag.should.equal(params.flag);
+      options.body.data.op.should.equal('add');
+      options.body.data.messages.should.equal(params.messages);
+    };
+    const output = {
+      msg: '',
+      result: 'success',
+    };
+    const stubs = common.getStubs(validator, output);
+    messages(common.config).flags.add(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
+  });
+
+  it('should mark message as unread', (done) => {
+    const params = {
+      flag: 'read',
+      messages: [131],
+    };
+    const validator = (url, options) => {
+      url.should.contain(`${common.config.apiURL}/messages/flags`);
+      options.method.should.be.equal('POST');
+      Object.keys(options.body.data).length.should.equal(3);
+      options.body.data.flag.should.equal(params.flag);
+      options.body.data.op.should.equal('remove');
+      options.body.data.messages.should.equal(params.messages);
+    };
+    const output = {
+      msg: '',
+      result: 'success',
+    };
+    const stubs = common.getStubs(validator, output);
+    messages(common.config).flags.remove(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
+  });
 });


### PR DESCRIPTION
This is a WIP continuation of https://github.com/zulip/zulip-js/pull/16, to use the new test / README style. The old comments are below:

> This is a work in progress to mark messages as read (among other things), thanks to @timabbott's helpful comment on the update pointer PR:
> 

> > More importantly, this isn't the right endpoint for marking something as read; this is the endpoint for moving the home view (which has a side effect of making some things read).
>  >
> > You want /messages/flags, and I would definitely implement it as the bulk operation, since that's almost always what one wants.

> 
> As always, feedback would be super helpful.
> 
> One thing that would be great is to have an description for the various flags - I think read/starred are pretty self-explanatory, the others I've listed are
> ['mentioned', 'wildcard_mentioned', 'has_alert_word', 'historical']. (there may be others that I've missed)