### PR TITLE
WIP: add support to update pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ zulip.callEndpoint('/messages', 'POST', params);
 | `zulip.users.me.subscriptions()` | POST `/users/me/subscriptions` | subscribes a user to a stream/streams. |
 | `zulip.users.create()` | POST `/users` | create a new user. |
 | `zulip.users.me.subscriptions.remove()` | DELETE `/users/me/subscriptions` | remove subscriptions. |
+| `zulip.users.me.pointer.update()` | POST `users/me/pointer` | updates the pointer for the user, for moving the home view. Accepts a message id. This has the side effect of marking some messages as read. Will not return success if the message id is invalid. Will always succeed if the id is less than the current value of the pointer (the id of the last message read). |
 
 # Testing
 

--- a/examples/users.js
+++ b/examples/users.js
@@ -38,8 +38,13 @@ zulip(config)
     z.users.me.subscriptions.remove(removeParams).then(console.log);
 
     // Get pointer for user
-    // Prints
-    // { msg: '', pointer: 3432741029383298, result: 'success' }
-    z.users.me.pointer.retrieve().then(console.log);
+    z.users.me.pointer.retrieve().then((resp) => {
+      // Prints
+      // { msg: '', pointer: 3432741029383298, result: 'success' }
+      console.log(resp);
+      // Update pointer for user (has the side effect of marking some messages as read)
+      // Prints success if the message id is valid
+      z.users.me.pointer.update(resp.pointer + 1).then(console.log);
+    });
   })
   .catch(err => console.log(err.msg));

--- a/src/resources/users.js
+++ b/src/resources/users.js
@@ -16,6 +16,10 @@ function users(config) {
           const url = `${config.apiURL}/users/me/pointer`;
           return api(url, config, 'GET', params);
         },
+        update: (id) => {
+          const url = `${config.apiURL}/users/me/pointer`;
+          return api(url, config, 'POST', { pointer: id });
+        },
       },
       getProfile: () => {
         const url = `${config.apiURL}/users/me`;

--- a/test/resources/users.js
+++ b/test/resources/users.js
@@ -64,6 +64,28 @@ describe('Users', () => {
     }).catch(done);
   });
 
+  it('should update pointer for user', (done) => {
+    const pointer = 172;
+    const validator = (url, options) => {
+      url.should.equal(`${common.config.apiURL}/users/me/pointer`);
+      options.method.should.be.equal('POST');
+      options.should.have.property('body');
+      Object.keys(options.body.data).length.should.equal(1);
+      options.body.data.pointer.should.equal(pointer);
+    };
+    const output = {
+      msg: '',
+      result: 'success',
+    };
+    const stubs = common.getStubs(validator, output);
+    users(common.config).me.pointer.update(pointer)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
+  });
+
   it('should fetch user profile', (done) => {
     const validator = (url, options) => {
       url.should.equal(`${common.config.apiURL}/users/me`);


### PR DESCRIPTION
This is a WIP PR to update https://github.com/zulip/zulip-js/pull/15 with the new style of tests etc.
The old comments are:
> This PR adds support to update a user's pointer, to move the home view. This lets you mark a message as read. This has a side effect of marking some messages as read.
> The usage is zulip.users.me.pointer.update(id) where id is the message id (or the current value of the pointer + 1).
> 
> This is a work in progress, and review/feedback would be appreciated!