### PR TITLE
WIP: add support to add/remove reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ zulip.callEndpoint('/messages', 'POST', params);
 | `zulip.messages.update()` | PATCH `/messages/<msg_id>` | updates the content or topic of the message with the given `msg_id`. |
 | `zulip.queues.register()` | POST `/register` | registers a new queue. You can pass it a params object with the types of events you are interested in and whether you want to receive raw text or html (using markdown). |
 | `zulip.queues.deregister()` | DELETE `/events` | deletes a previously registered queue. |
+| `zulip.reactions.add()` | POST `/reactions` | add a reaction to a message. Accepts a params object with `message_id` and `emoji`. |
+| `zulip.reactions.remove()` | DELETE `/reactions` | remove a reaction from a message. Accepts a params object with `message_id` and `emoji`. |
 | `zulip.streams.retrieve()` | GET `/streams` | returns a promise that can be used to retrieve all streams. |
 | `zulip.streams.getStreamId()` | GET `/get_stream_id` | returns a promise that can be used to retrieve a stream's id. |
 | `zulip.streams.subscriptions.retrieve()` | GET `/users/me/subscriptions` | returns a promise that can be used to retrieve the user's subscriptions. |

--- a/examples/reactions.js
+++ b/examples/reactions.js
@@ -1,0 +1,17 @@
+const zulip = require('../lib/');
+
+const config = {
+  username: process.env.ZULIP_USERNAME,
+  apiKey: process.env.ZULIP_API_KEY,
+  realm: process.env.ZULIP_REALM,
+};
+
+const params = {
+  message_id: 1,
+  emoji: 'smile',
+};
+
+zulip(config).then(z => z.reactions.add(params).then((resp) => {
+  console.log(resp);
+  return z.reactions.remove(params).then(console.log);
+})).catch(err => console.log(err.msg));

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ const events = require('./resources/events');
 const users = require('./resources/users');
 const emojis = require('./resources/emojis');
 const typing = require('./resources/typing');
+const reactions = require('./resources/reactions');
 
 function callEndpoint(endpoint, method = 'GET', params) {
   let finalendpoint = endpoint;
@@ -34,6 +35,7 @@ function resources(config) {
     users: users(config),
     emojis: emojis(config),
     typing: typing(config),
+    reactions: reactions(config),
   };
 }
 

--- a/src/resources/reactions.js
+++ b/src/resources/reactions.js
@@ -1,0 +1,12 @@
+const api = require('../api');
+
+function reactions(config) {
+  const url = `${config.apiURL}/reactions`;
+  const call = (method, params) => api(url, config, method, params);
+  return {
+    add: params => call('POST', params),
+    remove: params => call('DELETE', params),
+  };
+}
+
+module.exports = reactions;

--- a/test/resources/reactions.js
+++ b/test/resources/reactions.js
@@ -1,0 +1,55 @@
+const reactions = require('../../lib/resources/reactions');
+const common = require('../common');
+const chai = require('chai');
+chai.use(require('chai-as-promised'));
+
+chai.should();
+
+describe('Reactions', () => {
+  it('should add reaction to message', (done) => {
+    const params = {
+      message_id: 1,
+      emoji: 'smile',
+    };
+    const validator = (url, options) => {
+      url.should.equal(`${common.config.apiURL}/reactions`);
+      options.method.should.be.equal('POST');
+      Object.keys(options.body.data).length.should.equal(2);
+      options.body.data.message_id.should.equal(params.message_id);
+      options.body.data.emoji.should.equal(params.emoji);
+    };
+    const output = {
+      result: 'success',
+      msg: '',
+    };
+    const stubs = common.getStubs(validator, output);
+    reactions(common.config).add(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
+  });
+
+  it('should remove reaction from message', (done) => {
+    const messageID = 1;
+    const emoji = 'smile';
+    const params = { message_id: messageID, emoji };
+    const validator = (url, options) => {
+      url.should.equal(`${common.config.apiURL}/reactions?message_id=${messageID}&emoji=${emoji}`);
+      options.method.should.be.equal('DELETE');
+      options.should.not.have.property('body');
+    };
+    const output = {
+      result: 'success',
+      msg: '',
+    };
+    const stubs = common.getStubs(validator, output);
+    reactions(common.config).remove(params)
+    .then((data) => {
+      data.should.have.property('result', 'success');
+      common.restoreStubs(stubs);
+      done();
+    }).catch(done);
+  });
+});


### PR DESCRIPTION
This PR adds support to add or remove an emoji reaction to a message. 
The usage is `zulip.reactions.add({ message_id: 1, emoji: smile })` and `zulip.reactions.remove({ message_id: 1, emoji: smile })`

This is a work in progress, and review/feedback would be appreciated!