### PR TITLE
[WIP] Testable Examples

### DIFF
--- a/test/examples.js
+++ b/test/examples.js
@@ -1,0 +1,78 @@
+const zulip = require('../lib/index');
+const chai = require('chai');
+const fs = require('fs');
+chai.use(require('chai-as-promised'));
+
+chai.should();
+const fixtures = JSON.parse(fs.readFileSync('./test/fixtures.json', 'utf-8'));
+const examples = [];
+// Just the tokens for my local test server. Temporary.
+const config = {
+  username: 'cookie-bot@localhost',
+  apiKey: 'dLfydLvW3tJvSjwXZscOWKDyfl2vPfLI',
+  realm: 'http://localhost:9991/api',
+};
+
+examples.push({
+  name: 'stream-message',
+  code(client) {
+    // {code_example|start}
+    return client.messages.send({
+      to: 'Denmark',
+      type: 'stream',
+      subject: 'Castle',
+      content: 'Something is rotten in the state of Denmark.',
+    });
+    // {code_example|end}
+  },
+});
+
+examples.push({
+  name: 'private-message',
+  code(client) {
+    // {code_example|start}
+    return client.messages.send({
+      type: 'private',
+      to: 'iago@zulip.com',
+      content: 'I come not, friends, to steal away your hearts.',
+    });
+    // {code_example|end}
+  },
+});
+
+describe('Examples', () => {
+  it('should begin testing', (done) => {
+    // Without something like this, it doesn't detect other tests.
+    // Weird, but can work around by simply placing an empty test.
+    done();
+  });
+  zulip(config).then((client) => {
+    examples.forEach((elem) => {
+      it(`should pass example: ${elem.name}`, (done) => {
+        elem.code(client).then((result) => {
+          result.should.deep.equal(fixtures[elem.name]);
+          done();
+        }).catch(done);
+      });
+    });
+  });
+});
+
+// // Strings for adding to the example in the markdown.
+// const preExample = `
+// const zulip = require('zulip-js');
+// // Download zuliprc-dev from your dev server
+// const config = {
+//     zuliprc: 'zuliprc-dev',
+// };
+// zulip(config).then((client) => {
+// `;
+
+// const postExample = `
+// .then((result) => {
+//     console.log(result);
+// })
+// .catch((error) => {
+//     console.error(error);
+// });
+// `;

--- a/test/fixtures.json
+++ b/test/fixtures.json
@@ -1,0 +1,368 @@
+{
+    "add-subscriptions": {
+        "already_subscribed": {
+            "already_subscribed": {
+                "newbie@zulip.com": [
+                    "new stream"
+                ]
+            },
+            "msg": "",
+            "result": "success",
+            "subscribed": {}
+        },
+        "unauthorized_errors_fatal_false": {
+            "already_subscribed": {},
+            "msg": "",
+            "result": "success",
+            "subscribed": {},
+            "unauthorized": [
+                "private_stream"
+            ]
+        },
+        "unauthorized_errors_fatal_true": {
+            "msg": "Unable to access stream (private_stream).",
+            "result": "error"
+        },
+        "without_principals": {
+            "already_subscribed": {},
+            "msg": "",
+            "result": "success",
+            "subscribed": {
+                "iago@zulip.com": [
+                    "new stream"
+                ]
+            }
+        }
+    },
+    "create-user": {
+        "email_already_used_error": {
+            "msg": "Email 'newbie@zulip.com' already in use",
+            "result": "error"
+        },
+        "successful_response": {
+            "msg": "",
+            "result": "success"
+        }
+    },
+    "delete-queue": {
+        "bad_event_queue_id_error": {
+            "code": "BAD_EVENT_QUEUE_ID",
+            "msg": "Bad event queue id: 1518820930:1",
+            "queue_id": "1518820930:1",
+            "result": "error"
+        },
+        "successful_response": {
+            "msg": "",
+            "result": "success"
+        }
+    },
+    "get-all-streams": {
+        "msg": "",
+        "result": "success",
+        "streams": [
+            {
+                "description": "A Scandinavian country",
+                "invite_only": false,
+                "name": "Denmark",
+                "stream_id": 1
+            },
+            {
+                "description": "Yet another Italian city",
+                "invite_only": false,
+                "name": "Rome",
+                "stream_id": 2
+            },
+            {
+                "description": "Located in the United Kingdom",
+                "invite_only": false,
+                "name": "Scotland",
+                "stream_id": 3
+            },
+            {
+                "description": "A northeastern Italian city",
+                "invite_only": false,
+                "name": "Venice",
+                "stream_id": 4
+            },
+            {
+                "description": "A city in Italy",
+                "invite_only": false,
+                "name": "Verona",
+                "stream_id": 5
+            },
+            {
+                "description": "New stream for testing",
+                "invite_only": false,
+                "name": "new stream",
+                "stream_id": 6
+            }
+        ]
+    },
+    "get-all-users": {
+        "members": [
+            {
+                "avatar_url": "https://secure.gravatar.com/avatar/818c212b9f8830dfef491b3f7da99a14?d=identicon&version=1",
+                "bot_type": null,
+                "email": "AARON@zulip.com",
+                "full_name": "aaron",
+                "is_active": true,
+                "is_admin": false,
+                "is_bot": false,
+                "user_id": 1
+            },
+            {
+                "avatar_url": "https://secure.gravatar.com/avatar/77c3871a68c8d70356156029fd0a4999?d=identicon&version=1",
+                "bot_type": null,
+                "email": "cordelia@zulip.com",
+                "full_name": "Cordelia Lear",
+                "is_active": true,
+                "is_admin": false,
+                "is_bot": false,
+                "user_id": 3
+            },
+            {
+                "avatar_url": "https://secure.gravatar.com/avatar/0cbf08f3a355995fa2ec542246e35123?d=identicon&version=1",
+                "bot_type": null,
+                "email": "newbie@zulip.com",
+                "full_name": "New User",
+                "is_active": true,
+                "is_admin": false,
+                "is_bot": false,
+                "user_id": 24
+            }
+        ],
+        "msg": "",
+        "result": "success"
+    },
+    "get-events-from-queue": {
+        "events": [
+            {
+                "id": 0,
+                "message": {
+                    "avatar_url": "https://url/for/othello-bots/avatar",
+                    "client": "website",
+                    "content": "Something is rotten in the state of Denmark.",
+                    "content_type": "text/x-markdown",
+                    "display_recipient": "Denmark",
+                    "id": 12345678,
+                    "recipient_id": 12314,
+                    "sender_email": "othello-bot@example.com",
+                    "sender_full_name": "Othello Bot",
+                    "sender_id": 13215,
+                    "sender_realm_str": "example",
+                    "sender_short_name": "othello-bot",
+                    "subject": "Castle",
+                    "subject_links": [],
+                    "timestamp": 1375978403,
+                    "type": "stream"
+                },
+                "type": "message"
+            },
+            {
+                "id": 1,
+                "message": {
+                    "avatar_url": "https://url/for/othello-bots/avatar",
+                    "client": "website",
+                    "content": "I come not, friends, to steal away your hearts.",
+                    "content_type": "text/x-markdown",
+                    "display_recipient": [
+                        {
+                            "email": "hamlet@example.com",
+                            "full_name": "Hamlet of Denmark",
+                            "id": 31572,
+                            "short_name": "hamlet"
+                        }
+                    ],
+                    "id": 12345679,
+                    "recipient_id": 18391,
+                    "sender_email": "othello-bot@example.com",
+                    "sender_full_name": "Othello Bot",
+                    "sender_id": 13215,
+                    "sender_realm_str": "example",
+                    "sender_short_name": "othello-bot",
+                    "subject": "",
+                    "subject_links": [],
+                    "timestamp": 1375978404,
+                    "type": "private"
+                },
+                "type": "message"
+            }
+        ],
+        "msg": "",
+        "result": "success"
+    },
+    "get-profile": {
+        "client_id": "74c768b081076fdb3c4326256c17467e",
+        "email": "iago@zulip.com",
+        "full_name": "Iago",
+        "is_admin": true,
+        "is_bot": false,
+        "max_message_id": 30,
+        "msg": "",
+        "pointer": -1,
+        "result": "success",
+        "short_name": "iago",
+        "user_id": 5
+    },
+    "get-stream-id": {
+        "msg": "",
+        "result": "success",
+        "stream_id": 15
+    },
+    "get-subscribed-streams": {
+        "msg": "",
+        "result": "success",
+        "subscriptions": [
+            {
+                "audible_notifications": true,
+                "color": "#e79ab5",
+                "description": "A Scandinavian country",
+                "desktop_notifications": true,
+                "email_address": "Denmark+187b4125ed36d6af8b5d03ef4f65c0cf@zulipdev.com:9981",
+                "in_home_view": true,
+                "invite_only": false,
+                "name": "Denmark",
+                "pin_to_top": false,
+                "push_notifications": false,
+                "stream_id": 1,
+                "subscribers": [
+                    "ZOE@zulip.com",
+                    "hamlet@zulip.com",
+                    "iago@zulip.com",
+                    "othello@zulip.com",
+                    "prospero@zulip.com"
+                ]
+            },
+            {
+                "audible_notifications": true,
+                "color": "#e79ab5",
+                "description": "Located in the United Kingdom",
+                "desktop_notifications": true,
+                "email_address": "Scotland+f5786390183e60a1ccb18374f9d05649@zulipdev.com:9981",
+                "in_home_view": true,
+                "invite_only": false,
+                "name": "Scotland",
+                "pin_to_top": false,
+                "push_notifications": false,
+                "stream_id": 3,
+                "subscribers": [
+                    "ZOE@zulip.com",
+                    "iago@zulip.com",
+                    "othello@zulip.com",
+                    "prospero@zulip.com"
+                ]
+            },
+            {
+                "audible_notifications": true,
+                "color": "#e79ab5",
+                "description": "A city in Italy",
+                "desktop_notifications": true,
+                "email_address": "Verona+faaa92dc82cf143174ddc098a1c832ef@zulipdev.com:9981",
+                "in_home_view": true,
+                "invite_only": false,
+                "name": "Verona",
+                "pin_to_top": false,
+                "push_notifications": false,
+                "stream_id": 5,
+                "subscribers": [
+                    "AARON@zulip.com",
+                    "ZOE@zulip.com",
+                    "cordelia@zulip.com",
+                    "hamlet@zulip.com",
+                    "iago@zulip.com",
+                    "othello@zulip.com",
+                    "prospero@zulip.com"
+                ]
+            },
+            {
+                "audible_notifications": false,
+                "color": "#76ce90",
+                "description": "New stream for testing",
+                "desktop_notifications": false,
+                "email_address": "new%0032stream+e1917b4fc733268e91fcc57cf79a9249@zulipdev.com:9981",
+                "in_home_view": true,
+                "invite_only": false,
+                "name": "new stream",
+                "pin_to_top": false,
+                "push_notifications": false,
+                "stream_id": 6,
+                "subscribers": [
+                    "iago@zulip.com"
+                ]
+            }
+        ]
+    },
+    "invalid-api-key": {
+        "msg": "Invalid API key",
+        "result": "error"
+    },
+    "invalid-pm-recipient-error": {
+        "code": "BAD_REQUEST",
+        "msg": "Invalid email 'eeshan@zulip.com'",
+        "result": "error"
+    },
+    "invalid-stream-error": {
+        "code": "BAD_REQUEST",
+        "msg": "Invalid stream name 'nonexistent'",
+        "result": "error"
+    },
+    "missing-request-argument-error": {
+        "code": "REQUEST_VARIABLE_MISSING",
+        "msg": "Missing 'content' argument",
+        "result": "error",
+        "var_name": "content"
+    },
+    "nonexistent-stream-error": {
+        "code": "BAD_REQUEST",
+        "msg": "Stream 'nonexistent_stream' does not exist",
+        "result": "error"
+    },
+    "private-message": {
+        "id": 134,
+        "msg": "",
+        "result": "success"
+    },
+    "register-queue": {
+        "last_event_id": -1,
+        "msg": "",
+        "queue_id": "1517975029:0",
+        "result": "success"
+    },
+    "remove-subscriptions": {
+        "msg": "",
+        "not_subscribed": [],
+        "removed": [
+            "new stream"
+        ],
+        "result": "success"
+    },
+    "render-message": {
+        "msg": "",
+        "rendered": "<p><strong>foo</strong></p>",
+        "result": "success"
+    },
+    "stream-message": {
+        "id": 134,
+        "msg": "",
+        "result": "success"
+    },
+    "update-message": {
+        "msg": "",
+        "result": "success"
+    },
+    "update-message-edit-permission-error": {
+        "code": "BAD_REQUEST",
+        "msg": "You don't have permission to edit this message",
+        "result": "error"
+    },
+    "upload-file": {
+        "msg": "",
+        "result": "success",
+        "uri": "/user_uploads/1/4e/m2A3MSqFnWRLUf9SaPzQ0Up_/zulip.txt"
+    },
+    "user-not-authorized-error": {
+        "code": "BAD_REQUEST",
+        "msg": "User not authorized for this query",
+        "result": "error"
+    }
+}


### PR DESCRIPTION
This tries to mimic the structure of the python examples used in the /api page. For generating the example test, one would need to add the pre and post text to the code after remove the `return ` text in each example.

An alternate version that is more 'javascripty' could be to keep the examples in their own files and `eval` them to run that code.

Fixes #51 

@eeshangarg any pointers? 