### PR TITLE
Support git installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "fs-readfile-promise": "^3.0.0",
     "ini": "^1.3.4",
     "isomorphic-fetch": "^2.2.1",
-    "isomorphic-form-data": "0.0.1"
+    "isomorphic-form-data": "0.0.1",
+    "postinstall-build": "^3.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -30,10 +31,11 @@
     "sinon": "^4.1.2"
   },
   "scripts": {
-    "compile": "babel --presets es2015 -d lib/ src/",
-    "prepublish": "npm run compile",
+    "build": "babel --presets es2015 -d lib/ src/",
+    "postinstall": "postinstall-build lib",
+    "prepublish": "npm run build",
     "lint": "eslint src test examples",
-    "test": "npm run lint && npm run compile && mocha test/*"
+    "test": "npm run lint && npm run build && mocha test/*"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds support for git installs. Installing from a git url is useful to test development branches/PRs. 

This is achieved by using https://github.com/exogen/postinstall-build 

The build script is only run on post install if the build artifact does not exist (ie., it will not run on an npm install).

Note that this renames the compile script to build (and updates the prepublish script)