### PR TITLE
Use new reactions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ zulip.callEndpoint('/messages', 'POST', params);
 | `zulip.messages.flags.remove()` | POST `/messages/flags` | remove a flag from a list of messages. Its params are `flag` which is one of `[read, starred, mentioned, wildcard_mentioned, has_alert_word, historical]` and `messages` which is a list of messageIDs. |
 | `zulip.queues.register()` | POST `/register` | registers a new queue. You can pass it a params object with the types of events you are interested in and whether you want to receive raw text or html (using markdown). |
 | `zulip.queues.deregister()` | DELETE `/events` | deletes a previously registered queue. |
-| `zulip.reactions.add()` | POST `/reactions` | add a reaction to a message. Accepts a params object with `message_id` and `emoji`. |
-| `zulip.reactions.remove()` | DELETE `/reactions` | remove a reaction from a message. Accepts a params object with `message_id` and `emoji`. |
+| `zulip.reactions.add()` | POST `/reactions` | add a reaction to a message. Accepts a params object with `message_id`, `emoji_name`, `emoji_code` and `reaction_type` (default is `unicode_emoji`). |
+| `zulip.reactions.remove()` | DELETE `/reactions` | remove a reaction from a message. Accepts a params object with `message_id` and `emoji_code` and `reaction_type` (default is `unicode_emoji`). |
 | `zulip.streams.retrieve()` | GET `/streams` | returns a promise that can be used to retrieve all streams. |
 | `zulip.streams.getStreamId()` | GET `/get_stream_id` | returns a promise that can be used to retrieve a stream's id. |
 | `zulip.streams.subscriptions.retrieve()` | GET `/users/me/subscriptions` | returns a promise that can be used to retrieve the user's subscriptions. |

--- a/examples/reactions.js
+++ b/examples/reactions.js
@@ -8,7 +8,9 @@ const config = {
 
 const params = {
   message_id: 1,
-  emoji: 'smile',
+  emoji_name: 'musical_note',
+  emoji_code: '1f3b5',
+  reaction_type: 'unicode_emoji',
 };
 
 zulip(config).then(z => z.reactions.add(params).then((resp) => {

--- a/src/resources/reactions.js
+++ b/src/resources/reactions.js
@@ -1,8 +1,12 @@
 const api = require('../api');
 
 function reactions(config) {
-  const url = `${config.apiURL}/reactions`;
-  const call = (method, params) => api(url, config, method, params);
+  const url = messageID => `${config.apiURL}/messages/${messageID}/reactions`;
+  const call = (method, initParams) => {
+    const params = Object.assign({}, initParams);
+    delete params.message_id;
+    return api(url(initParams.message_id), config, method, params);
+  };
   return {
     add: params => call('POST', params),
     remove: params => call('DELETE', params),

--- a/test/resources/reactions.js
+++ b/test/resources/reactions.js
@@ -9,14 +9,17 @@ describe('Reactions', () => {
   it('should add reaction to message', (done) => {
     const params = {
       message_id: 1,
-      emoji: 'smile',
+      emoji_name: 'musical_note',
+      emoji_code: '1f3b5',
+      reaction_type: 'unicode_emoji',
     };
     const validator = (url, options) => {
-      url.should.equal(`${common.config.apiURL}/reactions`);
+      url.should.equal(`${common.config.apiURL}/messages/${params.message_id}/reactions`);
       options.method.should.be.equal('POST');
-      Object.keys(options.body.data).length.should.equal(2);
-      options.body.data.message_id.should.equal(params.message_id);
-      options.body.data.emoji.should.equal(params.emoji);
+      Object.keys(options.body.data).length.should.equal(3);
+      options.body.data.emoji_name.should.equal(params.emoji_name);
+      options.body.data.emoji_code.should.equal(params.emoji_code);
+      options.body.data.reaction_type.should.equal(params.reaction_type);
     };
     const output = {
       result: 'success',
@@ -32,11 +35,15 @@ describe('Reactions', () => {
   });
 
   it('should remove reaction from message', (done) => {
-    const messageID = 1;
-    const emoji = 'smile';
-    const params = { message_id: messageID, emoji };
+    const params = {
+      message_id: 1,
+      emoji_code: '1f3b5',
+      reaction_type: 'unicode_emoji',
+    };
     const validator = (url, options) => {
-      url.should.equal(`${common.config.apiURL}/reactions?message_id=${messageID}&emoji=${emoji}`);
+      const path = `${common.config.apiURL}/messages/${params.message_id}/reactions`;
+      const query = `emoji_code=${params.emoji_code}&reaction_type=${params.reaction_type}`;
+      url.should.equal(`${path}?${query}`);
       options.method.should.be.equal('DELETE');
       options.should.not.have.property('body');
     };


### PR DESCRIPTION
Update the reactions code to use the new API.

1. The url is `/messages/<message_id>/reactions`
2. The parameters are `emoji_code`, `emoji_name` (only required for `POST`) and `reaction_type` (default is `unicode_emoji`)

See @timabbott's comment: https://github.com/zulip/zulip-js/pull/50#issuecomment-370241630

https://github.com/zulip/zulip/blob/master/zproject/urls.py
```
  # New endpoint for handling reactions.                                                           
    url(r'^messages/(?P<message_id>[0-9]+)/reactions$',                                              
        rest_dispatch,                                                                               
        {'POST': 'zerver.views.reactions.add_reaction',                                              
         'DELETE': 'zerver.views.reactions.remove_reaction'}),   
```
https://github.com/zulip/zulip/blob/master/zerver/views/reactions.py
```
def add_reaction(request: HttpRequest, user_profile: UserProfile, message_id: int,
                 emoji_name: str=REQ(),
                 emoji_code: str=REQ(),
                 reaction_type: str=REQ(default="unicode_emoji")) -> HttpResponse:
```

```
def remove_reaction(request: HttpRequest, user_profile: UserProfile, message_id: int,
                    emoji_code: str=REQ(),
                    reaction_type: str=REQ(default="unicode_emoji")) -> HttpResponse:
```
