### PR TITLE
Updating README to use syntax using Promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ const config = {
   realm: process.env.ZULIP_REALM
 };
 
-const zulip = require('zulip-js')(config);
-
-zulip.streams.subscriptions().then(res => {
-  console.log(res);
+zulip(config).then(zulip => {
+  // The zulip object now initialized with config
+  zulip.streams.subscriptions().then(res => {
+    console.log(res);
+  });
 });
 ```
 


### PR DESCRIPTION
Updating README to use syntax using Promises. Readme example was written like this,
```
const zulip = require('zulip-js')(config);

zulip.streams.subscriptions().then(res => {
  console.log(res);
}); 
```
It should be updated to latest syntax using javascript promises, like this,

```
zulip(config).then(zulip => {
  // The zulip object now initialized with config
  zulip.streams.subscriptions().then(res => {
    console.log(res);
  });
});
```