### PR TITLE
Handle errors when getting api-key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,7 @@ function zulip(initialConfig) {
 
   if (!config.apiKey) {
     return accounts(config).retrieve().then((res) => {
+      if (res.error) return Promise.reject(res.msg)
       config.apiKey = res.api_key;
       return resources(config);
     });


### PR DESCRIPTION
like "API usage exceeded rate limit"

in my case the request failt with "malformed api-key" and it did not detect the error, when fetching the api key